### PR TITLE
Remove ending PHP closing tag and whitespace after.

### DIFF
--- a/Trustly.php
+++ b/Trustly.php
@@ -36,4 +36,3 @@ require_once('Trustly/Data/jsonrpcnotificationresponse.php');
 require_once('Trustly/Api/api.php');
 require_once('Trustly/Api/signed.php');
 require_once('Trustly/Api/unsigned.php');
-?>

--- a/Trustly/Api/api.php
+++ b/Trustly/Api/api.php
@@ -267,5 +267,3 @@ abstract class Trustly_Api {
 	abstract public function insertCredentials($request);
 
 }
-
-?>

--- a/Trustly/Api/signed.php
+++ b/Trustly/Api/signed.php
@@ -396,5 +396,3 @@ class Trustly_Api_Signed extends Trustly_Api {
 		return $api->hello();
 	}
 }
-
-?>

--- a/Trustly/Api/unsigned.php
+++ b/Trustly/Api/unsigned.php
@@ -135,4 +135,3 @@ class Trustly_Api_Unsigned extends Trustly_Api {
 		return $response;
 	}
 }
-?>

--- a/Trustly/Data/data.php
+++ b/Trustly/Data/data.php
@@ -128,5 +128,3 @@ class Trustly_Data {
 	}
 
 }
-
-?>

--- a/Trustly/Data/jsonrpcnotificationrequest.php
+++ b/Trustly/Data/jsonrpcnotificationrequest.php
@@ -84,5 +84,3 @@ class Trustly_Data_JSONRPCNotificationRequest extends Trustly_Data {
 		return $this->get('version');
 	}
 }
-
-?>

--- a/Trustly/Data/jsonrpcnotificationresponse.php
+++ b/Trustly/Data/jsonrpcnotificationresponse.php
@@ -123,5 +123,3 @@ class Trustly_Data_JSONRPCNotificationResponse extends Trustly_Data {
 	}
 }
 
-
-?>

--- a/Trustly/Data/jsonrpcrequest.php
+++ b/Trustly/Data/jsonrpcrequest.php
@@ -147,4 +147,3 @@ class Trustly_Data_JSONRPCRequest extends Trustly_Data_Request {
 		return NULL;
 	}
 }
-?>

--- a/Trustly/Data/jsonrpcresponse.php
+++ b/Trustly/Data/jsonrpcresponse.php
@@ -73,4 +73,3 @@ class Trustly_Data_JSONRPCResponse extends Trustly_Data_Response {
 	}
 }
 
-?>

--- a/Trustly/Data/jsonrpcsignedresponse.php
+++ b/Trustly/Data/jsonrpcsignedresponse.php
@@ -100,5 +100,3 @@ class Trustly_Data_JSONRPCSignedResponse extends Trustly_Data_JSONRPCResponse {
 	}
 }
 
-?>
-

--- a/Trustly/Data/request.php
+++ b/Trustly/Data/request.php
@@ -53,5 +53,3 @@ class Trustly_Data_Request extends Trustly_Data {
 		$this->method = $method;
 	}
 }
-
-?>

--- a/Trustly/Data/response.php
+++ b/Trustly/Data/response.php
@@ -128,5 +128,3 @@ class Trustly_Data_Response extends Trustly_Data {
 		return NULL;
 	}
 }
-
-?>

--- a/Trustly/exceptions.php
+++ b/Trustly/exceptions.php
@@ -42,5 +42,3 @@ class Trustly_SignatureException extends Exception {
 class Trustly_DataException extends Exception { }
 
 class Trustly_AuthentificationException extends Exception { }
-
-?>


### PR DESCRIPTION
Really no need to have this, and causing more problems than they solve.
I.e if i include this files i get a bunch of whitespace and messes up my
headers.
