### PR TITLE
Avoid a non-json string in request value

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,6 @@ Example notification processing
 -------------------------------
 
     $request = $api->handleNotification($notification_body);
-        # FIXME Handle the incoming notification data here
     $notifyresponse = $api->notificationResponse($request, TRUE);
 
     echo $notifyresponse->json();

--- a/Trustly/Data/jsonrpcnotificationrequest.php
+++ b/Trustly/Data/jsonrpcnotificationrequest.php
@@ -31,6 +31,10 @@ class Trustly_Data_JSONRPCNotificationRequest extends Trustly_Data {
 		$this->notification_body = $notification_body;
 		$payload = json_decode($notification_body, TRUE);
 
+		if(is_null($payload)) {
+			throw new Trustly_DataException('Empty notification');
+		}
+
 		parent::__construct($payload);
 
 		if($this->getVersion() != '1.1') {

--- a/example/www/php/example.php
+++ b/example/www/php/example.php
@@ -394,6 +394,9 @@ function notification() {
         } catch(Trustly_JSONRPCVersionException $e) {
             error_log('Got incoming notification with bad JSONRPC version');
             return ;
+        } catch(Trustly_DataException $e) {
+            error_log('Got incoming notification null');
+            return;
         }
 
         if(isset($notification)) {


### PR DESCRIPTION
If the request body is a empty string result in a fatal error, I have added a simple validation to avoid it.