### PR TITLE
Remove NBSP (U+00A0) character which breaks method type hinting

### DIFF
--- a/Trustly/Api/signed.php
+++ b/Trustly/Api/signed.php
@@ -53,7 +53,7 @@ class Trustly_Api_Signed extends Trustly_Api {
 	 *
 	 * @param string $username Username for the processing account used at Trustly.
 	 *
-	 * @param string $password Password for the processing account used at Trustly.
+	 * @param string $password Password for the processing account used at Trustly.
 	 *
 	 * @param string $host API host used for communication. Fully qualified
 	 *		hostname. When integrating with our public API this is typically
@@ -927,7 +927,7 @@ class Trustly_Api_Signed extends Trustly_Api {
 	 * @return Trustly_Data_JSONRPCSignedResponse
 	 */
 	public function accountPayout($notificationurl, $accountid, $enduserid,
-		$messageid, $amount, $currency, $holdnotifications=NULL) {
+		$messageid, $amount, $currency, $holdnotifications=NULL) {
 
 			$data = array(
 				'NotificationURL' => $notificationurl,
@@ -1155,7 +1155,7 @@ class Trustly_Api_Signed extends Trustly_Api {
 	 * @see https://trustly.com/en/developer/api#/charge
 	 *
 	 * @param string $accountid The AccountID received from an account
-	 *		notification with granted direct debit mandate from which the money 
+	 *		notification with granted direct debit mandate from which the money
 	 *		should be sent.
 	 *
 	 * @param string $notificationurl The URL to which notifications for this

--- a/Trustly/Api/unsigned.php
+++ b/Trustly/Api/unsigned.php
@@ -60,7 +60,7 @@ class Trustly_Api_Unsigned extends Trustly_Api {
 	 *
 	 * @param string $username Username for the processing account used at Trustly.
 	 *
-	 * @param string $password Password for the processing account used at Trustly.
+	 * @param string $password Password for the processing account used at Trustly.
 	 *
 	 * @param string $host API host used for communication. Fully qualified
 	 *		hostname. When integrating with our public API this is typically

--- a/example/www/js/example.js
+++ b/example/www/js/example.js
@@ -54,7 +54,7 @@ function deposit() {
 			if(data.result == 'ok') {
 				$('.iframe_container > iframe').prop('src', data.url).removeClass('hidden');
 				$('.iframe_container').removeClass('hidden');
-			} else {
+			} else {
 				failure('Failed to make deposit call', data.error);
 			}
 		},


### PR DESCRIPTION
Method `Trustly_Api_Signed->accountPayout(...)` did not work for php v7.2 (probably other versions too) because of this character being identified as a type hint for `$currency` argument.