### PR TITLE
Correct constructor signature

### DIFF
--- a/Trustly/Api/signed.php
+++ b/Trustly/Api/signed.php
@@ -53,7 +53,7 @@ class Trustly_Api_Signed extends Trustly_Api {
 	 *
 	 * @param string $username Username for the processing account used at Trustly.
 	 *
-	 * @param string $password Password for the processing account used at Trustly.
+	 * @param string $password Password for the processing account used at Trustly.
 	 *
 	 * @param string $host API host used for communication. Fully qualified
 	 *		hostname. When integrating with our public API this is typically


### PR DESCRIPTION
The separator is missing and instead there is a nbsp causing a warning when validating API usage