### PR TITLE
Fix error message for unknown cURL errors

### DIFF
--- a/Trustly/Api/api.php
+++ b/Trustly/Api/api.php
@@ -315,7 +315,7 @@ abstract class Trustly_Api {
 		$body = curl_exec($curl);
 		if($body === FALSE) {
 			$error = curl_error($curl);
-			if($error === NULL) {
+			if(!$error) {
 				$error = 'Failed to connect to the Trusly API';
 			}
 			throw new Trustly_ConnectionException($error);


### PR DESCRIPTION
curl_error() returns and empty string, not null.
https://www.php.net/manual/en/function.curl-error.php