### PR TITLE
Fix  license attribute in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
 	"description": "Implementation of communications with Trustly public API for Online bank e-payments. See https://trustly.com for more information",
 	"type": "library",
 	"homepage": "http://github.com/trustly/trustly-client-php",
-	"licence": "MIT",
+	"license": "MIT",
 	"keywords": [
 		"payment",
 		"trustly"


### PR DESCRIPTION
This fixes the warning on Packagist:

![image](https://github.com/trustly/trustly-client-php/assets/204594/0cbe902f-bb4f-4c1c-b836-c20febff491c)
