### PR TITLE
Correct minimum required PHP version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
 		"ext-openssl": "*",
 		"ext-curl": "*",
 		"ext-mbstring": "*",
-		"php": ">=5.2.0"
+		"php": ">=5.3.0"
 	},
 	"autoload": {
 		"files": ["Trustly.php"]


### PR DESCRIPTION
Since https://github.com/trustly/trustly-client-php/pull/20 was merged the required PHP version is now 5.3 and not 5.2.
https://www.php.net/manual/en/function.openssl-random-pseudo-bytes.php

This should be mostly fine since at this point testing with PHP 5.2 is problematic in it self since it's not available as a package on GitHub action and even composer 1.0.0 (or any beta version) required PHP 5.3.0 or higher.