### PR TITLE
PE-946 Changing the target endpoint to preferred

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Overview
 
 The code provided wrappers for calling the trustly API. Create an instance of
 the API call with you merchant criterias and use the stubs in that class for
-calling the API. The API will default to communicate with https://trustly.com,
+calling the API. The API will default to communicate with https://api.trustly.com,
 override the `host` parameter for the constructor to communicate with
 test.trustly.com instead.
 
@@ -58,7 +58,7 @@ Example deposit call
 
     require_once('Trustly.php');
 
-    /* Change 'test.trustly.com' to 'trustly.com' below to use the live environment */
+    /* Change 'test.trustly.com' to 'api.trustly.com' below to use the live environment */
     $api = new Trustly_Api_Signed(
                     $trustly_rsa_private_key,
                     $trustly_username,

--- a/Trustly/Api/api.php
+++ b/Trustly/Api/api.php
@@ -78,7 +78,7 @@ abstract class Trustly_Api {
 	 *
 	 * @param string $host API host used for communication. Fully qualified
 	 *		hostname. When integrating with our public API this is typically
-	 *		either 'test.trustly.com' or 'trustly.com'.
+	 *		either 'test.trustly.com' or 'api.trustly.com'.
 	 *
 	 * @param integer $port Port on API host used for communicaiton. Normally
 	 *		443 for https, or 80 for http.
@@ -86,7 +86,7 @@ abstract class Trustly_Api {
 	 * @param bool $is_https Indicator wether the port on the API host expects
 	 *		https.
 	 */
-	public function __construct($host='trustly.com', $port=443, $is_https=TRUE) {
+	public function __construct($host='api.trustly.com', $port=443, $is_https=TRUE) {
 		$this->api_is_https = $is_https;
 
 		if($this->loadTrustlyPublicKey($host, $port, $is_https) === FALSE) {
@@ -107,7 +107,7 @@ abstract class Trustly_Api {
 	 *
 	 * @param string $host API host used for communication. Fully qualified
 	 *		hostname. When integrating with our public API this is typically
-	 *		either 'test.trustly.com' or 'trustly.com'.
+	 *		either 'test.trustly.com' or 'api.trustly.com'.
 	 *
 	 * @param integer $port Port on API host used for communication. Normally
 	 *		443 for https, or 80 for http.
@@ -245,7 +245,7 @@ abstract class Trustly_Api {
 	 *
 	 * @param string $host API host used for communication. Fully qualified
 	 *		hostname. When integrating with our public API this is typically
-	 *		either 'test.trustly.com' or 'trustly.com'. NULL means do not change.
+	 *		either 'test.trustly.com' or 'api.trustly.com'. NULL means do not change.
 	 *
 	 * @param integer $port Port on API host used for communicaiton. Normally
 	 *		443 for https, or 80 for http. NULL means do not change.
@@ -397,7 +397,7 @@ abstract class Trustly_Api {
 	 * @return URL to the API peer with the given query path.
 	 */
 	public function url($request=NULL) {
-		return $this->baseURL() . $this->urlPath($request);
+		return $this->baseURL() . $this->urlPath($this->api_host, $request);
 	}
 
 
@@ -510,7 +510,7 @@ abstract class Trustly_Api {
 	 *
 	 * @return string The URL path
 	 */
-	abstract protected function urlPath($request=NULL);
+	abstract protected function urlPath($host="api.trustly.com", $request=NULL);
 
 	/**
 	 * Callback for handling the response from an API call. This call is

--- a/Trustly/Api/signed.php
+++ b/Trustly/Api/signed.php
@@ -57,15 +57,15 @@ class Trustly_Api_Signed extends Trustly_Api {
 	 *
 	 * @param string $host API host used for communication. Fully qualified
 	 *		hostname. When integrating with our public API this is typically
-	 *		either 'test.trustly.com' or 'trustly.com'.
+	 *		either 'test.trustly.com' or 'api.trustly.com'.
 	 *
 	 * @param integer $port Port on API host used for communicaiton. Normally
 	 *		443 for https, or 80 for http.
 	 *
-	 * @param bool $is_https Indicator wether the port on the API host expects
+	 * @param bool $is_https Indicator whether the port on the API host expects
 	 *		https.
 	 */
-	public function __construct($merchant_privatekey, $username, $password, $host='trustly.com', $port=443, $is_https=TRUE) {
+	public function __construct($merchant_privatekey, $username, $password, $host='api.trustly.com', $port=443, $is_https=TRUE) {
 
 		parent::__construct($host, $port, $is_https);
 
@@ -239,12 +239,21 @@ class Trustly_Api_Signed extends Trustly_Api {
 	 *
 	 * See specific class implementing the call for more information.
 	 *
+	 * @param string $host The host for the API call
 	 * @param Trustly_Data_JSONRPCRequest $request Data to send in the request
 	 *
 	 * @return string The URL path
 	 */
-	protected function urlPath($request=NULL) {
-		$url = '/api/1';
+	protected function urlPath($host=NULL, $request=NULL) {
+        switch ($host) {
+            case 'test.trustly.com':
+            case 'trustly.com':
+                $url = '/api/1';
+                break;
+            default:
+                $url = '/1';
+                break;
+        }
 		return $url;
 	}
 

--- a/Trustly/Api/unsigned.php
+++ b/Trustly/Api/unsigned.php
@@ -64,7 +64,7 @@ class Trustly_Api_Unsigned extends Trustly_Api {
 	 *
 	 * @param string $host API host used for communication. Fully qualified
 	 *		hostname. When integrating with our public API this is typically
-	 *		either 'test.trustly.com' or 'trustly.com'.
+	 *		either 'test.trustly.com' or 'api.trustly.com'.
 	 *
 	 * @param integer $port Port on API host used for communication. Normally
 	 *		443 for https, or 80 for http.
@@ -72,7 +72,7 @@ class Trustly_Api_Unsigned extends Trustly_Api {
 	 * @param bool $is_https Indicator wether the port on the API host expects
 	 *		https.
 	 **/
-	public function __construct($username, $password, $host='trustly.com', $port=443, $is_https=TRUE) {
+	public function __construct($username, $password, $host='api.trustly.com', $port=443, $is_https=TRUE) {
 		parent::__construct($host, $port, $is_https);
 
 		$this->api_username = $username;
@@ -91,7 +91,7 @@ class Trustly_Api_Unsigned extends Trustly_Api {
 	 *
 	 * @return string The URL path
 	 */
-	protected function urlPath($request=NULL) {
+	protected function urlPath($host=NULL, $request=NULL) {
 		return '/api/Legacy';
 	}
 

--- a/example/www/php/example.php
+++ b/example/www/php/example.php
@@ -399,8 +399,8 @@ function notification() {
         if(isset($notification)) {
             /* The method will reveal what type of incoming notification this 
              * is. Depending on the type of notification the contents will 
-             * differ. Read more of the different notifications and exakt 
-             * contents at https://trustly.com/en/developer/api */
+             * differ. Read more of the different notifications and exact
+             * contents at https://eu.developers.trustly.com/doc/reference/notifications-overview */
             $method = $notification->getMethod();
             /* The orderid will always be present in the notifications. This 
              * and the 'messageid' parameter is used to connect the order to 


### PR DESCRIPTION
The endpoint for incoming traffic onwards is api.trustly.com/1. The former (trustly.com/api/1) is kept alive for the immediate future but will be phased out.